### PR TITLE
Update GameOfLife runtime to 46

### DIFF
--- a/com.github.sixpounder.GameOfLife.json
+++ b/com.github.sixpounder.GameOfLife.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.sixpounder.GameOfLife",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/com.github.sixpounder.GameOfLife.json
+++ b/com.github.sixpounder.GameOfLife.json
@@ -34,43 +34,6 @@
         "*.a"
     ],
     "modules" : [
-    	{
-            "name": "libsass",
-            "builddir": true,
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/lazka/libsass.git",
-                    "branch": "meson",
-                    "commit": "aac79dccd3c8f7e8f22125f87a119f3b1ee9d487"
-                }
-            ]
-        },
-        {
-            "name": "sassc",
-            "builddir": true,
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/lazka/sassc.git",
-                    "branch": "meson",
-                    "commit": "a1950c2d95ea4c051feb90bb1f43559fbb54bf36"
-                }
-            ]
-        },
-        {
-            "name": "libadwaita",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "tag": "1.3.1"
-                }
-            ]
-        },
         {
             "name" : "game-of-life",
             "builddir" : true,

--- a/com.github.sixpounder.GameOfLife.json
+++ b/com.github.sixpounder.GameOfLife.json
@@ -51,6 +51,10 @@
                     "type" : "archive",
                     "url" : "https://github.com/sixpounder/game-of-life/releases/download/v0.4.0-1/game-of-life-0.4.0.tar.xz",
                     "sha256": "54635224537df1f9da754ea2e175b766ad7507b1615f53d819cbfacd958c425c"
+                },
+                {
+                    "type" : "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,58 @@
+From f47923345fddb8d8c73c60df104ce3481757eca6 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Thu, 13 Jun 2024 02:45:33 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/com.github.sixpounder.GameOfLife.appdata.xml.in.in | 6 ++++--
+ data/com.github.sixpounder.GameOfLife.desktop.in.in     | 2 +-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/data/com.github.sixpounder.GameOfLife.appdata.xml.in.in b/data/com.github.sixpounder.GameOfLife.appdata.xml.in.in
+index 24a5252..564e655 100644
+--- a/data/com.github.sixpounder.GameOfLife.appdata.xml.in.in
++++ b/data/com.github.sixpounder.GameOfLife.appdata.xml.in.in
+@@ -21,7 +21,7 @@
+         </ul>
+     </description>
+     <screenshots>
+-        <screenshot>
++        <screenshot type="default">
+           <image>https://raw.githubusercontent.com/sixpounder/game-of-life/main/data/screenshots/1.png</image>
+         </screenshot>
+         <screenshot>
+@@ -36,6 +36,8 @@
+     </screenshots>
+     <launchable type="desktop-id">@APPLICATION_ID@.desktop</launchable>
+     <url type="homepage">https://github.com/sixpounder/game-of-life</url>
++    <url type="bugtracker">https://github.com/sixpounder/game-of-life/issues</url>
++    <url type="vcs-browser">https://github.com/sixpounder/game-of-life</url>
+     <developer_name>Andrea Coronese</developer_name>
+     <update_contact>sixpounder_at_protonmail.com</update_contact>
+     <translation type="gettext">game-of-life</translation>
+@@ -118,7 +120,7 @@
+                         Fixes a few problems with the main menu entries
+                     </li>
+                     <li>
+-                        <b>Layout changes</b>: Moves main menu to the left of the window, introduce close button to the right
++                        Layout changes: Moves main menu to the left of the window, introduce close button to the right
+                     </li>
+                 </ul>
+             </description>
+diff --git a/data/com.github.sixpounder.GameOfLife.desktop.in.in b/data/com.github.sixpounder.GameOfLife.desktop.in.in
+index be08716..2a17a68 100644
+--- a/data/com.github.sixpounder.GameOfLife.desktop.in.in
++++ b/data/com.github.sixpounder.GameOfLife.desktop.in.in
+@@ -5,7 +5,7 @@ Exec=game-of-life
+ Icon=@APPLICATION_ID@
+ Terminal=false
+ Type=Application
+-Categories=GNOME;GTK;
++Categories=GNOME;GTK;Game;
+ StartupNotify=true
+ X-SingleMainWindow=true
+ Keywords=simulation;game;
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update GameOfLife runtime to 46 since runtime version 44 has reached end-of-life.
- Use libadwaita from runtime.
- Fix appdata papercuts.